### PR TITLE
Change className to array

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -16,7 +16,7 @@ const defaultLazyImagesConfig = {
   placeholderQuality: 60,
   imgSelector: 'img',
   transformImgPath,
-  className: 'lazyload',
+  className: ['lazyload'],
   cacheFile: '.lazyimages.json',
   appendInitScript: true,
   scriptSrc: 'https://cdn.jsdelivr.net/npm/lazysizes@5/lazysizes.min.js',
@@ -112,7 +112,7 @@ const processImage = async imgElem => {
 
   imgElem.setAttribute('loading', 'lazy');
   imgElem.setAttribute('data-src', imgElem.src);
-  imgElem.classList.add(className);
+  imgElem.classList.add(...className);
 
   if (imgElem.hasAttribute('srcset')) {
     const srcSet = imgElem.getAttribute('srcset');

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -112,7 +112,9 @@ const processImage = async imgElem => {
 
   imgElem.setAttribute('loading', 'lazy');
   imgElem.setAttribute('data-src', imgElem.src);
-  imgElem.classList.add(...className);
+
+  const classNameArr = Array.isArray(className) ? className : [className];
+  imgElem.classList.add(...classNameArr);
 
   if (imgElem.hasAttribute('srcset')) {
     const srcSet = imgElem.getAttribute('srcset');

--- a/readme.md
+++ b/readme.md
@@ -85,7 +85,7 @@ A full list of available configuration options are listed below.
 | `appendInitScript` | Boolean | Appends code to initialise lazy loading of images to the generated markup. Set this to `false` if you include your own lazy load script.<br>Default: `true` |
 | `scriptSrc` | String | The URI for the lazy load script that is injected into the markup via `appendInitScript`.<br>Default: `https://cdn.jsdelivr.net/npm/lazysizes@5/lazysizes.min.js` |
 | `preferNativeLazyLoad` | Boolean | Use the native browser `loading="lazy"` instead of the lazy load script (if available). Set this to `false` if you always want to use the lazy load script.<br>Default: `true` |
-| `className` | String | The class name added to found IMG elements. Do not change this value unless you intend to use your own `scriptSrc`.<br>Default: `lazyload` |
+| `className` | Array | The class names added to found IMG elements. Do not change this value unless you intend to use your own `scriptSrc`.<br>Default: `['lazyload']` |
 
 ## Example projects
 


### PR DESCRIPTION
lazysizes supports blurring images using the following;
```
.blur-up {
  -webkit-filter: blur(5px);
  filter: blur(5px);
  transition: filter 400ms, -webkit-filter 400ms;
}

.blur-up.lazyloaded {
  -webkit-filter: blur(0);
  filter: blur(0);
}
```

To allow this, you need to add both the `lazyload` and `blur-up` class to the image. IMO, the best way to do this is switch `className` to an array to allow for multiple classes.