### PR TITLE
Fix outputPath error with permalink: false

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -176,7 +176,7 @@ const transformMarkup = async (rawContent, outputPath) => {
   const { imgSelector, appendInitScript, scriptSrc, preferNativeLazyLoad } = lazyImagesConfig;
   let content = rawContent;
 
-  if (outputPath.endsWith('.html')) {
+  if (outputPath && outputPath.endsWith('.html')) {
     const dom = new JSDOM(content);
     const images = [...dom.window.document.querySelectorAll(imgSelector)];
 


### PR DESCRIPTION
Fixes https://github.com/liamfiddler/eleventy-plugin-lazyimages/issues/12 with code found in an [Eleventy issue](https://github.com/11ty/eleventy/issues/653).