### PR TITLE
Handling Unsplash querystring format

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -129,7 +129,7 @@ const processImage = async (imgElem, options) => {
 
   if (!fileExt) {
     // Twitter and similar pass the file format in the querystring, e.g. "?format=jpg"
-    fileExt = querystring.parse(parsedUrl.query).format;
+    fileExt = querystring.parse(parsedUrl.query).format || querystring.parse(parsedUrl.query).fm;
   }
 
   if (preferNativeLazyLoad) {


### PR DESCRIPTION
Hello Liam,

I've recently been using Ghost as a headless CMS, and found that when I tried using it with their Eleventy starter theme the build would fail whilst processing images. After doing a little digging, I found that Unsplash abbreviates "format" to "fm" inside the query string (so was causing the file extension to be set as null).

So my pull request is a small adjustment that follows on from this previous pull request, which allows for the format to be passed via the URL:

https://github.com/liamfiddler/eleventy-plugin-lazyimages/pull/16

Thank you for the amazing plug-in, and please let me know if you require any changes to my suggestion.

Samuel